### PR TITLE
Move to python3

### DIFF
--- a/SirepRAT.py
+++ b/SirepRAT.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/SirepRAT.py
+++ b/SirepRAT.py
@@ -95,7 +95,7 @@ def sirep_connect(sock, dst_ip, verbose=False):
     version_guid_banner = sock.recv(SIREP_VERSION_GUID_LEN)
     logging.info('Banner hex: %s' % version_guid_banner)
     if verbose:
-        print "RECV:"
+        print("RECV:")
         hexdump.hexdump(version_guid_banner)
 
 
@@ -104,7 +104,7 @@ def sirep_send_command(sirep_con_sock, sirep_command, print_printable_data=False
     sirep_payload = sirep_command.serialize_sirep()
     logging.info('Sirep payload hex: %s' % sirep_payload.encode('hex'))
     if verbose:
-        print "SEND:"
+        print("SEND:")
         hexdump.hexdump(sirep_payload)
 
     # Send the Sirep payload
@@ -130,13 +130,13 @@ def sirep_send_command(sirep_con_sock, sirep_command, print_printable_data=False
 
             logging.info("Result record data hex: %s" % data[:LOGGING_DATA_TRUNCATION].encode('hex'))
             if verbose:
-                print "RECV:"
+                print("RECV:")
                 hexdump.hexdump(data)
 
             # If printable, print result record data as is
             if print_printable_data and all([x in string.printable for x in data]):
                 logging.info("Result data readable print:")
-                print "---------\n%s\n---------" % data
+                print("---------\n%s\n---------" % data)
             records.append(first_int + data)
         except socket.timeout as e:
             logging.debug("timeout in command communication. Assuming end of conversation")
@@ -176,7 +176,7 @@ def main(args):
             result_type_code = struct.unpack("I", result_buffer[:INT_SIZE])[0]
             sirep_result_ctor = RESULT_TYPE_TO_RESULT[result_type_code]
             sirep_result = sirep_result_ctor(result_buffer)
-            print sirep_result
+            print(sirep_result)
             sirep_results.append(sirep_result)
     finally:
         logging.debug("Closing socket")
@@ -224,7 +224,7 @@ if "__main__" == __name__:
                         help="Verbose - if printable, print result")
     parser.add_argument('--vv', action='store_true', default=False,
                         help="Very verbose - print socket buffers and more")
-    
+
     args = parser.parse_args()
 
     if args.command_type == CommandType.LaunchCommandWithOutput.name:

--- a/SirepRAT.py
+++ b/SirepRAT.py
@@ -138,7 +138,7 @@ def sirep_send_command(sirep_con_sock, sirep_command, print_printable_data=False
                 try:
                     data_string = data.decode()
                     logging.info("Result data readable print:")
-                    print("---------\n%s\n---------" % data)
+                    print("---------\n%s\n---------" % data_string)
                 except UnicodeError:
                     pass
 
@@ -176,13 +176,12 @@ def main(args):
         sirep_result_buffers = sirep_send_command(sock, sirep_command, print_printable_data=args.v or args.vv,
                                                   verbose=args.vv)
 
-        sirep_results = []
         for result_buffer in sirep_result_buffers:
             result_type_code = unpack_uint(result_buffer[:INT_SIZE])
             sirep_result_ctor = RESULT_TYPE_TO_RESULT[result_type_code]
             sirep_result = sirep_result_ctor(result_buffer)
             print(sirep_result)
-            sirep_results.append(sirep_result)
+
     finally:
         logging.debug("Closing socket")
         sock.close()

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/constants.py
+++ b/common/constants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/enums/CommandType.py
+++ b/common/enums/CommandType.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/enums/ResultRecordType.py
+++ b/common/enums/ResultRecordType.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/enums/WriteRecordType.py
+++ b/common/enums/WriteRecordType.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/enums/__init__.py
+++ b/common/enums/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/mappings.py
+++ b/common/mappings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/mappings.py
+++ b/common/mappings.py
@@ -38,8 +38,8 @@ Date:       2018-02-04 08:03:08
 
 import types
 
-from enums.CommandType import CommandType
-from enums.ResultRecordType import ResultRecordType
+from .enums.CommandType import CommandType
+from .enums.ResultRecordType import ResultRecordType
 from models import commands
 from models import results
 

--- a/common/mappings.py
+++ b/common/mappings.py
@@ -49,7 +49,7 @@ def _load_sirep_commands(module, base_class, type_enum, suffix_length):
     _sirep_commands = {}
     for symbol_name in dir(module):
         symbol = getattr(module, symbol_name)
-        if not isinstance(symbol, (type, types.ClassType)):
+        if not isinstance(symbol, type):
             continue
         # fill only classes that derive from given base class
         if issubclass(symbol, base_class) and \

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -110,8 +110,32 @@ def unpack_string(data):
     if len(data) < INT_SIZE:
         return ''
 
-    string_length = unpack_uint(data[:INT_SIZE])
-    return data[INT_SIZE:INT_SIZE + string_length].decode('utf-16le')
+    length = unpack_uint(data[:INT_SIZE])
+    return data[INT_SIZE:INT_SIZE+length].decode(SIREP_ENCODING)
+
+
+def unpack_strings(data):
+    """
+    Returns a tuple of multiple strings found in the data.
+    """
+    strings = []
+    start, end = 0, INT_SIZE
+
+    while end < len(data):
+        length = unpack_uint(data[start:end])
+
+        if length < 1:
+            break
+
+        start, end = end, end+length
+
+        if end > len(data):
+            break
+
+        strings.append(data[start:end].decode(SIREP_ENCODING))
+        start, end = end, end+INT_SIZE
+
+    return tuple(strings)
 
 
 def unpack_string_array(data):

--- a/common/utils.py
+++ b/common/utils.py
@@ -39,52 +39,100 @@ Date:       2018-02-04 08:03:08
 import struct
 from datetime import datetime
 
-from common.constants import MOUSTACHE_PREFIX, MOUSTACHE_SUFFIX
+from common.constants import INT_SIZE, MOUSTACHE_PREFIX, MOUSTACHE_SUFFIX
 
 # http://support.microsoft.com/kb/167296
 EPOCH_FILETIME = 116444736000000000
 HUNDRED_NANOSECONDS = 10000000
 
 
-def string_to_unicode(string_):
-    """Converts a given ASCII string to unicode"""
-    return "".join([c.ljust(2, "\x00") for c in string_])
+def pack_uint(uint):
+    return struct.pack('I', uint)
 
 
-def pack_string(string_):
+def pack_uints(*uints):
+    return struct.pack('I'*len(uints), *uints)
+
+
+def pack_string(string):
     """
     Returns given string, binary packed according to the Sirep protocol.
 
-    The given ASCII string is converted to the Sirep compatible struct:
-    -------------------------------------------------
-    |		Integer		|		Unicode bytes		|
-    -------------------0x4-------------------------len
-    |	length in bytes	|		Unicode chars		|
-    -------------------------------------------------
+    Sirep encodes strings in UTF-16 little endian, with a 4-byte unsigned integer in front.
     """
-    return struct.pack("%ss" % (len(string_) * 2), string_to_unicode(string_))
+    encoded_string = string.encode('utf-16le')
+    return struct.pack("I%ss" % len(encoded_string), len(encoded_string), encoded_string)
+
+
+def pack_string_array(*strings):
+    """
+    An array of strings is packed the following way:
+    1. A table with the offset and length of each string as 4-byte unsigned integers
+    2. The unsigned integer 0
+    3. All strings concatenated
+    """
+    encoded_strings = [s.encode('utf-16le') for s in strings]
+
+    table = []
+    # first offset is after the table, i.e. 2 integers for each string and the zero
+    offset = (2 * len(encoded_strings) + 1) * INT_SIZE
+
+    for length in map(len, encoded_strings):
+        table += [offset, length]
+        offset += length
+
+    # add the zero
+    table += [0]
+
+    # return the packed table plus the concatenated encoded strings
+    return pack_uints(*table) + b''.join(encoded_strings)
+
+
+def unpack_uint(data):
+    return struct.unpack('I', data)[0]
+
+
+def unpack_uints(data):
+    count = len(data) // INT_SIZE
+
+    return struct.unpack('I'*count, data)
 
 
 def unpack_string(data):
     """
-    Returns the packed string as an ASCII string.
+    Returns the packed string as UTF-8 string.
 
     Unpacks a binary packed string from a Sirep protocol buffer.
     """
-    if len(data) < 4:
-        return ""
-    string_size = struct.unpack("I", data[:4])[0]
-    return struct.unpack("%ss" % string_size, data[4:4 + string_size])[0].replace("\x00", "")
+    if len(data) < INT_SIZE:
+        return ''
+
+    string_length = unpack_uint(data[:INT_SIZE])
+    return data[INT_SIZE:INT_SIZE + string_length].decode('utf-16le')
+
+
+def unpack_string_array(data):
+    strings = []
+
+    for header in data[::INT_SIZE*2]:
+        offset, length = unpack_uints(header)
+
+        if offset == 0:
+            break
+
+        strings.append(data[offset:offset + length])
+
+    return tuple(strings)
 
 
 def unpack_bytes(data, data_size=None):
     """
     """
-    if len(data) < 4:
+    if len(data) < INT_SIZE:
         return ""
     if data_size is None:
-        data_size = struct.unpack("I", data[:4])[0]
-        return struct.unpack("%ss" % data_size, data[4:4 + data_size])[0]
+        data_size = unpack_uint(data[:INT_SIZE])
+        return struct.unpack("%ss" % data_size, data[INT_SIZE:INT_SIZE + data_size])[0]
     else:
         return struct.unpack("%ss" % data_size, data[:data_size])[0]
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -78,7 +78,7 @@ def pack_string_array(*strings):
 
     table = []
     # first offset is after the table, i.e. 2 integers for each string and the zero
-    offset = (2 * len(encoded_strings) + 1) * INT_SIZE
+    offset = (2 * len(encoded_strings) + 3) * INT_SIZE
 
     for length in map(len, encoded_strings):
         table += [offset, length]

--- a/common/utils.py
+++ b/common/utils.py
@@ -46,6 +46,9 @@ EPOCH_FILETIME = 116444736000000000
 HUNDRED_NANOSECONDS = 10000000
 
 
+SIREP_ENCODING = 'utf-16le'
+
+
 def pack_uint(uint):
     return struct.pack('I', uint)
 
@@ -60,7 +63,7 @@ def pack_string(string):
 
     Sirep encodes strings in UTF-16 little endian, with a 4-byte unsigned integer in front.
     """
-    encoded_string = string.encode('utf-16le')
+    encoded_string = string.encode(SIREP_ENCODING)
     return struct.pack("I%ss" % len(encoded_string), len(encoded_string), encoded_string)
 
 
@@ -71,7 +74,7 @@ def pack_string_array(*strings):
     2. The unsigned integer 0
     3. All strings concatenated
     """
-    encoded_strings = [s.encode('utf-16le') for s in strings]
+    encoded_strings = [s.encode(SIREP_ENCODING) for s in strings]
 
     table = []
     # first offset is after the table, i.e. 2 integers for each string and the zero
@@ -120,7 +123,7 @@ def unpack_string_array(data):
         if offset == 0:
             break
 
-        strings.append(data[offset:offset + length])
+        strings.append(data[offset:offset+length].decode(SIREP_ENCODING))
 
     return tuple(strings)
 
@@ -150,4 +153,5 @@ def windows_filetime_to_string(windows_filetime_low, windows_filetime_high):
 
 def windows_low_high_to_int(windows_int_low, windows_int_high):
     """Returns an int given the low and high integers"""
-    return (windows_int_high << 32) + windows_int_low
+    return (windows_int_high << 33) + windows_int_low
+

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/GetFileFromDeviceCommand.py
+++ b/models/commands/GetFileFromDeviceCommand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/GetFileFromDeviceCommand.py
+++ b/models/commands/GetFileFromDeviceCommand.py
@@ -36,8 +36,6 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
-
 import common.utils as utils
 from .SirepCommand import SirepCommand
 from common.constants import INT_SIZE
@@ -59,19 +57,17 @@ class GetFileFromDeviceCommand(SirepCommand):
 
         The payload length for this command type is the unicode length of the remote path.
         """
-        return len(self.remote_path) * 2
+        return 2*len(self.remote_path)
 
     def serialize_sirep(self):
         """Described in parent class"""
-        serialized = ""
-        # serialize the command global headers
-        serialized += struct.pack("II", self.command_type.value, self.payload_length)
-        # serialize the remote path parameter
-        serialized += utils.pack_string(self.remote_path)
-        return serialized
+        return b''.join((
+            utils.pack_uint(self.command_type.value),
+            utils.pack_string(self.remote_path),
+            ))
 
     @staticmethod
     def deserialize_sirep(self, command_buffer):
         """Described in parent class"""
-        remote_path = utils.unpack_string(command_buffer[INT_SIZE * 2:])
+        remote_path = utils.unpack_string(command_buffer[2*INT_SIZE:])
         return GetFileFromDeviceCommand(remote_path)

--- a/models/commands/GetFileFromDeviceCommand.py
+++ b/models/commands/GetFileFromDeviceCommand.py
@@ -39,7 +39,7 @@ Date:       2018-02-04 08:03:08
 import struct
 
 import common.utils as utils
-from SirepCommand import SirepCommand
+from .SirepCommand import SirepCommand
 from common.constants import INT_SIZE
 from common.enums.CommandType import CommandType
 

--- a/models/commands/GetFileInformationFromDeviceCommand.py
+++ b/models/commands/GetFileInformationFromDeviceCommand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/GetFileInformationFromDeviceCommand.py
+++ b/models/commands/GetFileInformationFromDeviceCommand.py
@@ -39,7 +39,7 @@ Date:       2018-02-04 08:03:08
 import struct
 
 import common.utils as utils
-from SirepCommand import SirepCommand
+from .SirepCommand import SirepCommand
 from common.constants import INT_SIZE
 from common.enums.CommandType import CommandType
 

--- a/models/commands/GetFileInformationFromDeviceCommand.py
+++ b/models/commands/GetFileInformationFromDeviceCommand.py
@@ -36,8 +36,6 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
-
 import common.utils as utils
 from .SirepCommand import SirepCommand
 from common.constants import INT_SIZE
@@ -59,19 +57,17 @@ class GetFileInformationFromDeviceCommand(SirepCommand):
 
         The payload length for this command type is the unicode length of the remote path.
         """
-        return len(self.remote_path) * 2
+        return 2*len(self.remote_path)
 
     def serialize_sirep(self):
         """Described in parent class"""
-        serialized = ""
-        # serialize the command global headers
-        serialized += struct.pack("II", self.command_type.value, self.payload_length)
-        # serialize the remote path parameter
-        serialized += utils.pack_string(self.remote_path)
-        return serialized
+        return b''.join((
+            utils.pack_uint(self.command_type.value),
+            utils.pack_string(self.remote_path),
+            ))
 
     @staticmethod
     def deserialize_sirep(self, command_buffer):
         """Described in parent class"""
-        remote_path = utils.unpack_string(command_buffer[INT_SIZE * 2:])
+        remote_path = utils.unpack_string(command_buffer[2*INT_SIZE:])
         return GetFileInformationFromDeviceCommand(remote_path)

--- a/models/commands/GetSystemInformationFromDeviceCommand.py
+++ b/models/commands/GetSystemInformationFromDeviceCommand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/GetSystemInformationFromDeviceCommand.py
+++ b/models/commands/GetSystemInformationFromDeviceCommand.py
@@ -36,7 +36,7 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-from SirepCommand import SirepCommand
+from .SirepCommand import SirepCommand
 from common.enums.CommandType import CommandType
 
 

--- a/models/commands/LaunchCommandWithOutputCommand.py
+++ b/models/commands/LaunchCommandWithOutputCommand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/LaunchCommandWithOutputCommand.py
+++ b/models/commands/LaunchCommandWithOutputCommand.py
@@ -74,7 +74,7 @@ class LaunchCommandWithOutputCommand(SirepCommand):
 
         The payload length for this command type is the unicode length of the remote path.
         """
-        return sum(self.HEADER_SIZE,
+        return sum(2*INT_SIZE, # return flags
                 7*INT_SIZE, # string array table with offset+length for all three strings
                 2*len(self.command_line_string),
                 2*len(self.parameters_string),

--- a/models/commands/LaunchCommandWithOutputCommand.py
+++ b/models/commands/LaunchCommandWithOutputCommand.py
@@ -39,7 +39,7 @@ Date:       2018-02-04 08:03:08
 import struct
 
 import common.utils as utils
-from SirepCommand import SirepCommand
+from .SirepCommand import SirepCommand
 from common.constants import TRUE_FLAG_STRINGS, INT_SIZE
 from common.enums.CommandType import CommandType
 

--- a/models/commands/LaunchCommandWithOutputCommand.py
+++ b/models/commands/LaunchCommandWithOutputCommand.py
@@ -74,12 +74,13 @@ class LaunchCommandWithOutputCommand(SirepCommand):
 
         The payload length for this command type is the unicode length of the remote path.
         """
-        return sum(2*INT_SIZE, # return flags
-                7*INT_SIZE, # string array table with offset+length for all three strings
-                2*len(self.command_line_string),
-                2*len(self.parameters_string),
-                2*len(self.base_directory_path),
-                )
+        return sum((
+            2*INT_SIZE, # return flags
+            7*INT_SIZE, # string array table with offset+length for all three strings
+            2*len(self.command_line_string),
+            2*len(self.parameters_string),
+            2*len(self.base_directory_path),
+            ))
 
     def serialize_sirep(self):
         """Described in parent class"""

--- a/models/commands/PutFileOnDeviceCommand.py
+++ b/models/commands/PutFileOnDeviceCommand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/PutFileOnDeviceCommand.py
+++ b/models/commands/PutFileOnDeviceCommand.py
@@ -39,7 +39,7 @@ Date:       2018-02-04 08:03:08
 import struct
 
 import common.utils as utils
-from SirepCommand import SirepCommand
+from .SirepCommand import SirepCommand
 from common.enums.CommandType import CommandType
 from common.constants import INT_SIZE
 from common.enums.WriteRecordType import WriteRecordType

--- a/models/commands/PutFileOnDeviceCommand.py
+++ b/models/commands/PutFileOnDeviceCommand.py
@@ -36,8 +36,6 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
-
 import common.utils as utils
 from .SirepCommand import SirepCommand
 from common.enums.CommandType import CommandType
@@ -58,16 +56,17 @@ class PutFileOnDeviceCommand(SirepCommand):
         return len(self.remote_path) * 2
 
     def serialize_sirep(self):
-        serialized = ""
-        serialized += struct.pack("II", self.command_type.value, self.payload_length)
-        serialized += utils.pack_string(self.remote_path)
-        serialized += struct.pack("II", self.write_record_type.value, self.data_length)
-        serialized += utils.pack_string(self.data)
-        return serialized
+        """Described in parent class"""
+        return b''.join((
+            utils.pack_uint(self.command_type.value),
+            utils.pack_string(self.remote_path),
+            utils.pack_uint(self.write_record_type.value),
+            utils.pack_string(self.data),
+            ))
 
     @staticmethod
     def deserialize_sirep(self, command_buffer):
-        command_type, payload_length = struct.unpack("II", command_buffer[:INT_SIZE * 2])
-        remote_path = utils.unpack_string(command_buffer[INT_SIZE * 2:])
-        data = utils.unpack_string(command_buffer[INT_SIZE * 2 + INT_SIZE + len(remote_path) * 2:])
+        command_type, payload_length = utils.unpack_uints(command_buffer[:2*INT_SIZE])
+        remote_path = utils.unpack_string(command_buffer[2*INT_SIZE:])
+        data = utils.unpack_string(command_buffer[2*INT_SIZE + INT_SIZE + 2*len(remote_path):])
         return PutFileOnDeviceCommand(remote_path, data)

--- a/models/commands/PutFileOnDeviceCommand.py
+++ b/models/commands/PutFileOnDeviceCommand.py
@@ -67,6 +67,6 @@ class PutFileOnDeviceCommand(SirepCommand):
     @staticmethod
     def deserialize_sirep(self, command_buffer):
         command_type, payload_length = utils.unpack_uints(command_buffer[:2*INT_SIZE])
-        remote_path = utils.unpack_string(command_buffer[2*INT_SIZE:])
-        data = utils.unpack_string(command_buffer[2*INT_SIZE + INT_SIZE + 2*len(remote_path):])
+        remote_path, data = utils.unpack_strings(command_buffer[2*INT_SIZE:])
         return PutFileOnDeviceCommand(remote_path, data)
+

--- a/models/commands/SirepCommand.py
+++ b/models/commands/SirepCommand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/SirepCommand.py
+++ b/models/commands/SirepCommand.py
@@ -36,9 +36,10 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
 from pprint import pformat
 
+from common.constants import INT_SIZE
+import common.utils as utils
 
 class SirepCommand(object):
     """Base class for all Sirep commands"""
@@ -58,7 +59,7 @@ class SirepCommand(object):
 
         Serialization is done according to the Sirep protocol.
         """
-        return struct.pack("II", self.command_type.value, self.payload_length)
+        return utils.pack_uints(self.command_type.value, self.payload_length)
 
     @staticmethod
     def deserialize_sirep(self, command_buffer):
@@ -67,7 +68,7 @@ class SirepCommand(object):
 
         Instances are built from the given binary command buffer.
         """
-        command_type, payload_length = struct.unpack("II", command_buffer)
+        command_type, payload_length = utils.unpack_uints(command_buffer[:2*INT_SIZE])
         return SirepCommand(command_type)
 
     def __repr__(self):

--- a/models/commands/__init__.py
+++ b/models/commands/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/commands/__init__.py
+++ b/models/commands/__init__.py
@@ -35,12 +35,12 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-08-19 08:03:08
 """
 
-from GetFileFromDeviceCommand import GetFileFromDeviceCommand
-from GetFileInformationFromDeviceCommand import GetFileInformationFromDeviceCommand
-from GetSystemInformationFromDeviceCommand import GetSystemInformationFromDeviceCommand
-from LaunchCommandWithOutputCommand import LaunchCommandWithOutputCommand
-from PutFileOnDeviceCommand import PutFileOnDeviceCommand
-from SirepCommand import SirepCommand
+from .GetFileFromDeviceCommand import GetFileFromDeviceCommand
+from .GetFileInformationFromDeviceCommand import GetFileInformationFromDeviceCommand
+from .GetSystemInformationFromDeviceCommand import GetSystemInformationFromDeviceCommand
+from .LaunchCommandWithOutputCommand import LaunchCommandWithOutputCommand
+from .PutFileOnDeviceCommand import PutFileOnDeviceCommand
+from .SirepCommand import SirepCommand
 
 __all__ = [
     "SirepCommand",

--- a/models/results/ErrorStreamResult.py
+++ b/models/results/ErrorStreamResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/ErrorStreamResult.py
+++ b/models/results/ErrorStreamResult.py
@@ -36,7 +36,7 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-from SirepResult import SirepResult
+from .SirepResult import SirepResult
 from common.constants import INT_SIZE
 
 

--- a/models/results/FileInformationResult.py
+++ b/models/results/FileInformationResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/FileInformationResult.py
+++ b/models/results/FileInformationResult.py
@@ -39,7 +39,7 @@ Date:       2018-02-04 08:03:08
 import struct
 
 import common.utils as utils
-from SirepResult import SirepResult
+from .SirepResult import SirepResult
 from common.constants import FILE_INFORMATION_SIZE
 
 

--- a/models/results/FileInformationResult.py
+++ b/models/results/FileInformationResult.py
@@ -36,8 +36,6 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
-
 import common.utils as utils
 from .SirepResult import SirepResult
 from common.constants import FILE_INFORMATION_SIZE
@@ -66,7 +64,7 @@ class FileInformationResult(SirepResult):
         dwHighDateTime_LastAccess, \
         dwLowDateTime_LastWrite, \
         dwHighDateTime_LastWrite = \
-            struct.unpack("IIIIIIIIII", result_payload[:FILE_INFORMATION_SIZE])
+            utils.unpack_uints(result_payload[:FILE_INFORMATION_SIZE])
         if HResult == 0x0:
             kv['file_size'] = utils.windows_low_high_to_int(nFileSizeLow, nFileSizeHigh)
             kv['time_created'] = utils.windows_filetime_to_string(dwLowDateTime_Created, dwHighDateTime_Created)

--- a/models/results/FileResult.py
+++ b/models/results/FileResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/FileResult.py
+++ b/models/results/FileResult.py
@@ -36,7 +36,7 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-from SirepResult import SirepResult
+from .SirepResult import SirepResult
 from common.constants import INT_SIZE
 
 

--- a/models/results/HResultResult.py
+++ b/models/results/HResultResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/HResultResult.py
+++ b/models/results/HResultResult.py
@@ -36,10 +36,9 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
-
 from .SirepResult import SirepResult
 from common.constants import INT_SIZE
+import common.utils as utils
 
 
 class HResultResult(SirepResult):
@@ -55,7 +54,7 @@ class HResultResult(SirepResult):
         """Described in parent class"""
         kv = super(HResultResult,
                    HResultResult)._parse_payload_to_kv(result_payload)
-        kv['HResult'] = struct.unpack("I", result_payload[:INT_SIZE])[0]
+        kv['HResult'] = utils.unpack_uint(result_payload[:INT_SIZE])
         return kv
 
     def __str__(self):

--- a/models/results/HResultResult.py
+++ b/models/results/HResultResult.py
@@ -38,7 +38,7 @@ Date:       2018-02-04 08:03:08
 
 import struct
 
-from SirepResult import SirepResult
+from .SirepResult import SirepResult
 from common.constants import INT_SIZE
 
 

--- a/models/results/OutputStreamResult.py
+++ b/models/results/OutputStreamResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/OutputStreamResult.py
+++ b/models/results/OutputStreamResult.py
@@ -36,7 +36,7 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-from SirepResult import SirepResult
+from .SirepResult import SirepResult
 from common.constants import INT_SIZE
 
 

--- a/models/results/SirepResult.py
+++ b/models/results/SirepResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/SirepResult.py
+++ b/models/results/SirepResult.py
@@ -36,7 +36,6 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-02-04 08:03:08
 """
 
-import struct
 from pprint import pformat
 
 import common.utils as utils
@@ -48,7 +47,7 @@ class SirepResult(object):
 
     def __init__(self, raw_data, data_size=None):
         """Initializes the result buffer representation"""
-        result_type = struct.unpack("I", raw_data[:INT_SIZE])[0]
+        result_type = utils.unpack_uint(raw_data[:INT_SIZE])
         result_payload = utils.unpack_bytes(raw_data[INT_SIZE:], data_size=data_size)
         self.result_type = result_type
         self.payload_length = len(result_payload)

--- a/models/results/SirepResult.py
+++ b/models/results/SirepResult.py
@@ -59,14 +59,8 @@ class SirepResult(object):
         """Returns the parsed result data, parsed into a dictionary"""
         return {}
 
-    def _get_payload_peek(self, size=20):
-        payload_peek = ""
-        if len(self.result_payload) > 0:
-            if len(self.result_payload) > size:
-                payload_peek = self.result_payload[:size]
-            else:
-                payload_peek = self.result_payload
-        return payload_peek.replace("\n", "").replace("\r", "")
+    def _get_payload_peek(self, size=50):
+        return self.result_payload[:size]
 
     def get_result_type(self):
         """Returns the result type (type ResultRecordType)"""

--- a/models/results/SystemInformationResult.py
+++ b/models/results/SystemInformationResult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/SystemInformationResult.py
+++ b/models/results/SystemInformationResult.py
@@ -38,7 +38,7 @@ Date:       2018-02-04 08:03:08
 
 import struct
 
-from SirepResult import SirepResult
+from .SirepResult import SirepResult
 from common.constants import OS_VERSION_INFO_EX_SIZE
 
 

--- a/models/results/__init__.py
+++ b/models/results/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 BSD 3-Clause License
 

--- a/models/results/__init__.py
+++ b/models/results/__init__.py
@@ -35,13 +35,13 @@ Author:     Dor Azouri <dor.azouri@safebreach.com>
 Date:       2018-08-19 08:03:08
 """
 
-from ErrorStreamResult import ErrorStreamResult
-from FileInformationResult import FileInformationResult
-from FileResult import FileResult
-from HResultResult import HResultResult
-from OutputStreamResult import OutputStreamResult
-from SirepResult import SirepResult
-from SystemInformationResult import SystemInformationResult
+from .ErrorStreamResult import ErrorStreamResult
+from .FileInformationResult import FileInformationResult
+from .FileResult import FileResult
+from .HResultResult import HResultResult
+from .OutputStreamResult import OutputStreamResult
+from .SirepResult import SirepResult
+from .SystemInformationResult import SystemInformationResult
 
 __all__ = [
     "SirepResult",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     url="https://github.com/SafeBreach-Labs/SirepRAT",
     packages=setuptools.find_packages(),
     classifiers=[
-        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Intended Audience :: Information Technology",
@@ -28,5 +28,5 @@ setuptools.setup(
         "Topic :: System :: System Shells",
         "Topic :: Utilities",
     ],
-    python_requires='=2.7',
+    python_requires='=3.1',
 )


### PR DESCRIPTION
Python 2 has been officially deprecated and is no longer the default on most systems.
This collection of patches makes the code run with python 3 instead of 2.